### PR TITLE
Allows androids to be tended with repair kits

### DIFF
--- a/Source/HarmonyPatches.cs
+++ b/Source/HarmonyPatches.cs
@@ -313,7 +313,7 @@ namespace Androids
           Pawn healer,
           Pawn patient)
         {
-            if (!patient.def.HasModExtension<MechanicalPawnProperties>())
+            if (!patient.def.HasModExtension<MechanicalPawnProperties>()  && !patient.def.HasModExtension<AndroidPawnProperties>())
                 return true;
             Thing thing;
             if (patient.playerSettings == null || patient.playerSettings.medCare <= MedicalCareCategory.NoMeds)
@@ -338,7 +338,7 @@ namespace Androids
 
         public static bool Patch_Toils_Tend_FinalizeTend(ref Toil __result, Pawn patient)
         {
-            if (!patient.def.HasModExtension<MechanicalPawnProperties>())
+            if (!patient.def.HasModExtension<MechanicalPawnProperties>()  && !patient.def.HasModExtension<AndroidPawnProperties>())
                 return true;
             Toil toil = new Toil();
             toil.initAction = (Action)(() =>


### PR DESCRIPTION
This should allow androids to be repaired with the kits. They were before, but because they dont have MechanicalPawnProperties (as it would give them things an ddisable certain things needed for androids, but not droids. It cant be used. But androids are assigned that empty mod extension.